### PR TITLE
add <form> and 'submit' binding to submit on enter keypress

### DIFF
--- a/app/views/Messaging/inbox.scala.html
+++ b/app/views/Messaging/inbox.scala.html
@@ -69,14 +69,16 @@
       </div>
       <div class="clearfix"></div>
       <div class="mail-message">
-        <div class="input-group">
-          <input type="text" class="form-control input-md" name="message" placeholder="Write a message" data-bind="textInput: $root.messageDraft">
-          <div class="input-group-btn">
-            <button type="submit" class="btn btn-md btn-primary" data-bind="click: $root.sendMessage">
-              Send
-            </button>
+	<form data-bind="submit: $root.sendMessage">
+          <div class="input-group">
+            <input type="text" class="form-control input-md" name="message" placeholder="Write a message" data-bind="textInput: $root.messageDraft">
+            <div class="input-group-btn">
+              <button type="submit" class="btn btn-md btn-primary">
+                Send
+              </button>
+            </div>
           </div>
-        </div>
+	</form>
       </div>
     </div>
     <div class="mail-box">

--- a/public/js/app/inbox.js
+++ b/public/js/app/inbox.js
@@ -168,6 +168,7 @@ window.App = function() {
         if(match.participants()[0]==newMessage.to) match.messages.unshift(new _.messageModel(newMessage));
       });
     });
+    return false;
   }
 
   _.getUpdates = function() {


### PR DESCRIPTION
This is an improvement over having to navigate the cursor to the Send button. Now, the user can hit "enter" on the keyboard and submit/send the message.