### PR TITLE
add null check around object member access

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -166,9 +166,11 @@
             type: "GET",
             dataType: "json",
             success: function(data) {
-              if(data.notifications.length > 0) {
-                createNotification(data.notifications.length);
-                clearNotifications();
+              if(data.notifications !== null) {
+                if(data.notifications.length > 0) {
+                  createNotification(data.notifications.length);
+                  clearNotifications();
+                }
               }
             }
           });


### PR DESCRIPTION
because JavaScript Console in Firefox was erroring about accessing a null member.

Solves issue #63.