### PR TITLE
add compile-time and runtime checks for compatible java version

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -18,6 +18,10 @@ object Global extends GlobalSettings {
    */
   override def onStart(app: Application) {
 
+    val jvmVersion = sys.props("java.specification.version").toDouble
+    if (jvmVersion != 1.7)
+      throw new RuntimeException(s"Unsupported JRE: java.specification.version $jvmVersion != 1.7")
+
     // make sure the bot is instantiated and running
     TinderBot.context ! BotCommand("run")
 

--- a/build.sbt
+++ b/build.sbt
@@ -58,4 +58,10 @@ libraryDependencies ++= Seq(
   "net.sourceforge.parallelcolt"  %  "parallelcolt"               % "0.10.0"
   )     
 
+initialize := {
+  val required = "1.7"
+  val current  = sys.props("java.specification.version")
+  assert(current == required, s"Unsupported JDK: java.specification.version $current != $required")
+}
+
 play.Project.playScalaSettings


### PR DESCRIPTION
This should prevent future issue #58 and other such version-related issues.