### PR TITLE
Fixed issue #69

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -188,7 +188,7 @@
             console.log("Good news, facial data models are valid!");
           } else {
             var html = '<div class="alert alert-warning"><b>Heads Up!</b> TinderBot is not yet swiping. Head to Matchmaker and make more swipes to train the bot.</div>'
-            $("div.wrapper.wrapper-content").prepend(html);
+            $("#page-wrapper > div.wrapper.wrapper-content").prepend(html);
           }
         }
       });


### PR DESCRIPTION
by selecting a more accurate and single element in the JQuery selector, as opposed to the general `<div>` element it had before, which caused the header/warning to show up in more than one place. See issue #69 .