### PR TITLE
Replaced eigenvector computation with a more memory scalable algorithm.

### DIFF
--- a/app/utils/face/EigenFaces.scala
+++ b/app/utils/face/EigenFaces.scala
@@ -1,6 +1,5 @@
 package utils.face
 
-import scala.collection.JavaConversions._
 import cern.colt.matrix.DoubleMatrix2D
 import cern.colt.matrix.impl.DenseDoubleMatrix2D
 
@@ -22,8 +21,7 @@ object EigenFaces {
    */
   def computeEigenFaces(pixelMatrix: Array[Array[Double]], meanColumn: Array[Double]): DoubleMatrix2D = {
     val diffMatrix = MatrixHelpers.computeDifferenceMatrixPixels(pixelMatrix, meanColumn)
-    val covarianceMatrix = MatrixHelpers.computeCovarianceMatrix(pixelMatrix, diffMatrix)
-    val eigenVectors = MatrixHelpers.computeEigenVectors(covarianceMatrix)
+    val eigenVectors = MatrixHelpers.computeEigenVectors(diffMatrix)
     computeEigenFaces(eigenVectors, diffMatrix)
   }
 


### PR DESCRIPTION
Addresses #42 

Memory efficient computation of pixel matrix eigenvectors as specified by [Turk and Pentland](http://www.face-rec.org/algorithms/PCA/jcn.pdf).